### PR TITLE
chore(deps): bump Jetty to  9.4.56.v20240826

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.55.v20240627</version>
+            <version>9.4.56.v20240826</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Addresses https://github.com/apache/sling-org-apache-sling-connection-timeout-agent/security/dependabot/12